### PR TITLE
authenticate_user filter does not error out if no submission

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -9,7 +9,7 @@ class SubmissionsController < ApplicationController
     if submission
       redirect_to submission
     else
-      redirect_to :root
+      redirect_to :login
     end
   end
 
@@ -46,11 +46,11 @@ class SubmissionsController < ApplicationController
   protected
 
   def current_user
-    super || current_submission.user
+    super || current_submission.try(:user)
   end
 
   def current_submission
-    Submission.find params[:id]
+    Submission.find params[:id] if params[:id].present?
   end
 
   def submission_params


### PR DESCRIPTION
Thanks again for the help today :pray:

We were still having mailer config issues, so we decided to use `/submissions/mine` as the url to send out to people.  

When an user is not logged, that url breaks as a submission ID does not exist.  This fix solved the issue for us. 
